### PR TITLE
installation: add backports.lzma dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 requirements = [
+    'backports.lzma>=0.0.3',
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio-base>=0.2.1',


### PR DESCRIPTION
- FIX Adds missing dependency to backports.lzma.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
