### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -38,8 +38,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Utils.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-utils
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_utils/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_utils/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-utils 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-15 15:24+0200\n"
 "PO-Revision-Date: 2015-09-15 15:24+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_utils/translations/es/LC_MESSAGES/messages.po
+++ b/invenio_utils/translations/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-utils 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-15 15:24+0200\n"
 "PO-Revision-Date: 2015-09-15 15:24+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_utils/translations/fr/LC_MESSAGES/messages.po
+++ b/invenio_utils/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-utils 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-15 15:24+0200\n"
 "PO-Revision-Date: 2015-09-15 15:24+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_utils/translations/invenio.pot
+++ b/invenio_utils/translations/invenio.pot
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-utils 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-15 15:24+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_utils/translations/it/LC_MESSAGES/messages.po
+++ b/invenio_utils/translations/it/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-utils 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-15 15:24+0200\n"
 "PO-Revision-Date: 2015-09-15 15:24+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ directory = invenio_utils/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_utils/translations/invenio.pot
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     keywords='invenio TODO',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-utils',
     packages=[
         'invenio_utils',

--- a/tests/test_utils_vcs_git.py
+++ b/tests/test_utils_vcs_git.py
@@ -54,7 +54,7 @@ class GitHarvestTest(InvenioTestCase):
         # Setup git user config.
         call([self.which_git, 'config', 'user.name', 'Invenio Software'])
         call([self.which_git, 'config', 'user.email',
-              'info@invenio-software.org'])
+              'info@inveniosoftware.org'])
 
         call(['touch', self.path + 'test.txt'])
         call([self.which_git, 'add', self.path + 'test.txt'])


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
